### PR TITLE
[FEAT] 챌린지 메인 및 선택페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2922,7 +2922,8 @@
     "node_modules/@stomp/stompjs": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.1.1.tgz",
-      "integrity": "sha512-chcDs6YkAnKp1FqzwhGvh3i7v0+/ytzqWdKYw6XzINEKAzke/iD00dNgFPWSZEqktHOK+C1gSzXhLkLbARIaZw=="
+      "integrity": "sha512-chcDs6YkAnKp1FqzwhGvh3i7v0+/ytzqWdKYw6XzINEKAzke/iD00dNgFPWSZEqktHOK+C1gSzXhLkLbARIaZw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -7622,6 +7623,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
       "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
         "eventsource": "^2.0.2",

--- a/src/pages/challenge/Challenge.vue
+++ b/src/pages/challenge/Challenge.vue
@@ -1,21 +1,60 @@
 <template>
-  <div class="page-container">
-    <h1 class="page-title">Challenge 페이지 제목</h1>
-    <p>이곳에 페이지의 상세 내용을 구성하세요.</p>
+  <div class="flex flex-col h-screen">
+    <!-- Header -->
+    <Header 
+      :show-logo="true" 
+      :show-points="true" 
+      :points="1250" />
+
+    <!-- Main Content Area -->
+    <div class="flex-1 flex items-center justify-center pt-[60px] pb-[90px] px-5">
+      <!-- Empty State Container - 328 × 296 -->
+      <div class="w-[328px] h-[296px] text-center flex flex-col justify-center">
+        <!-- Icon Circle - 하얀색 배경 -->
+        <div class="w-20 h-20 bg-white rounded-full flex items-center justify-center mx-auto mb-8">
+          <span class="text-primary-red text-3xl">🏆</span>
+        </div>
+
+        <!-- Main Text -->
+        <h2 class="text-white text-2xl font-bold mb-6 leading-tight font-pretendard">
+          아직 참여 중인<br />
+          챌린지가 없어요
+        </h2>
+
+        <!-- Subtitle -->
+        <div class="text-white text-base font-pretendard space-y-1 mb-12">
+          <p>새로운 도전을 통해</p>
+          <p>소비 습관을 개선해볼까요?</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Start Challenge Button - 컨테이너 밖으로 분리 -->
+    <div class="px-8 pb-[90px]">
+      <Button 
+        label="챌린지 시작하기" 
+        :disabled="false"
+        @click="startChallenge"
+      />
+    </div>
   </div>
 </template>
 
 <script setup>
-// 페이지별 스크립트 로직
+import { useRouter } from 'vue-router';
+import Header from '@/components/layout/Header.vue';
+import Button from '@/components/Button.vue';
+
+const router = useRouter();
+
+const startChallenge = () => {
+  // 챌린지 시작 로직 또는 다음 페이지로 이동
+  console.log('챌린지 시작하기 클릭됨');
+  // 예: router.push('/challenge/create');
+  // 예: router.push('/challenge/list');
+};
 </script>
 
 <style scoped>
-.page-container {
-  padding: 1.5rem;
-}
-.page-title {
-  font-size: 1.75rem;
-  font-weight: bold;
-  margin-bottom: 1.5rem;
-}
+/* 고정 크기 스타일 - 반응형 없음 */
 </style>

--- a/src/pages/challenge/Challenge.vue
+++ b/src/pages/challenge/Challenge.vue
@@ -1,57 +1,63 @@
 <template>
-  <div class="flex flex-col h-screen">
-    <!-- Header -->
-    <Header 
-      :show-logo="true" 
-      :show-points="true" 
-      :points="1250" />
+  <div>
+    <!-- Main Challenge Page -->
+    <div v-if="!showChallengeFlow" class="flex flex-col h-screen">
+      <!-- Header -->
+      <Header 
+        :show-logo="true" 
+        :show-points="true" 
+        :points="1250" 
+      />
 
-    <!-- Main Content Area -->
-    <div class="flex-1 flex items-center justify-center pt-[60px] pb-[90px] px-5">
-      <!-- Empty State Container - 328 × 296 -->
-      <div class="w-[328px] h-[296px] text-center flex flex-col justify-center">
-        <!-- Icon Circle - 하얀색 배경 -->
-        <div class="w-20 h-20 bg-white rounded-full flex items-center justify-center mx-auto mb-8">
-          <span class="text-primary-red text-3xl">🏆</span>
+      <!-- Main Content Area -->
+      <div class="flex-1 flex items-center justify-center pt-[60px] pb-[90px] px-5">
+        <!-- Empty State Container - 328 × 296 -->
+        <div class="w-[328px] h-[296px] text-center flex flex-col justify-center">
+          <!-- Icon Circle - 하얀색 배경 -->
+          <div class="w-20 h-20 bg-white rounded-full flex items-center justify-center mx-auto mb-8">
+            <i class="fas fa-trophy text-4xl" style="color: #FF5555;"></i>
+          </div>
+
+          <!-- Main Text -->
+          <h2 class="text-white text-2xl font-bold mb-6 leading-tight font-pretendard">
+            아직 참여 중인<br />
+            챌린지가 없어요
+          </h2>
+
+          <!-- Subtitle -->
+          <div class="text-white text-base font-pretendard space-y-1 mb-12">
+            <p>새로운 도전을 통해</p>
+            <p>소비 습관을 개선해볼까요?</p>
+          </div>
         </div>
+      </div>
 
-        <!-- Main Text -->
-        <h2 class="text-white text-2xl font-bold mb-6 leading-tight font-pretendard">
-          아직 참여 중인<br />
-          챌린지가 없어요
-        </h2>
-
-        <!-- Subtitle -->
-        <div class="text-white text-base font-pretendard space-y-1 mb-12">
-          <p>새로운 도전을 통해</p>
-          <p>소비 습관을 개선해볼까요?</p>
-        </div>
+      <!-- Start Challenge Button - 컨테이너 밖으로 분리 -->
+      <div class="px-8 pb-[90px]">
+        <Button 
+          label="챌린지 시작하기" 
+          :disabled="false"
+          @click="startChallenge"
+        />
       </div>
     </div>
 
-    <!-- Start Challenge Button - 컨테이너 밖으로 분리 -->
-    <div class="px-8 pb-[90px]">
-      <Button 
-        label="챌린지 시작하기" 
-        :disabled="false"
-        @click="startChallenge"
-      />
-    </div>
+    <!-- Challenge Flow (Loading + Selection) -->
+    <ChallengeFlow v-if="showChallengeFlow" />
   </div>
 </template>
 
 <script setup>
-import { useRouter } from 'vue-router';
+import { ref } from 'vue';
 import Header from '@/components/layout/Header.vue';
 import Button from '@/components/Button.vue';
+import ChallengeFlow from './ChallengeFlow.vue';
 
-const router = useRouter();
+const showChallengeFlow = ref(false);
 
 const startChallenge = () => {
-  // 챌린지 시작 로직 또는 다음 페이지로 이동
   console.log('챌린지 시작하기 클릭됨');
-  // 예: router.push('/challenge/create');
-  // 예: router.push('/challenge/list');
+  showChallengeFlow.value = true;
 };
 </script>
 

--- a/src/pages/challenge/ChallengeDaysInput.vue
+++ b/src/pages/challenge/ChallengeDaysInput.vue
@@ -1,0 +1,202 @@
+<template>
+    <div class="flex flex-col h-screen bg-default">
+      <!-- Header -->
+      <Header 
+        :show-logo="true" 
+        :show-points="true" 
+        :points="1250" 
+      />
+  
+      <!-- Timer Circle - Top Section -->
+      <div class="flex flex-col items-center pt-[60px] pb-4">
+        <div class="relative mb-6">
+          <div class="w-20 h-20 relative">
+            <!-- Background Circle -->
+            <svg class="w-20 h-20 transform -rotate-90" viewBox="0 0 80 80">
+              <circle 
+                cx="40" 
+                cy="40" 
+                r="36.5" 
+                stroke="#414141" 
+                stroke-width="7" 
+                fill="none"
+              />
+              <!-- Progress Circle -->
+              <circle 
+                cx="40" 
+                cy="40" 
+                r="36.5" 
+                stroke="#FF5555" 
+                stroke-width="7" 
+                fill="none"
+                :stroke-dasharray="circumference"
+                :stroke-dashoffset="dashOffset"
+                stroke-linecap="round"
+                class="transition-all duration-1000 ease-linear"
+              />
+            </svg>
+            <!-- Timer Number -->
+            <div class="absolute inset-0 flex items-center justify-center">
+              <span class="text-white text-2xl font-normal font-pretendard">{{ timeLeft }}</span>
+            </div>
+          </div>
+        </div>
+  
+        <!-- Main Title -->
+        <h1 class="text-white text-xl font-bold text-center mb-2 font-pretendard">
+          원하는 날짜를 입력해주세요
+        </h1>
+  
+        <!-- Subtitle -->
+        <div class="text-white/90 text-sm text-center font-pretendard">
+          <p>30초 후에 선택하지 않으면</p>
+          <p>랜덤으로 배정됩니다</p>
+        </div>
+      </div>
+  
+      <!-- Middle Content - 날짜 입력 중앙 배치 -->
+      <div class="flex-1 flex flex-col items-center justify-center">
+        <!-- Date Input Field -->
+        <div class="flex items-baseline justify-center mb-8">
+          <input
+            v-model="selectedDays"
+            type="number"
+            min="7"
+            max="35"
+            class="text-white text-6xl font-semibold font-pretendard bg-transparent border-none outline-none text-center w-32"
+            @input="validateInput"
+            @blur="handleBlur"
+            placeholder=""
+          />
+          <span class="text-white text-3xl font-semibold font-pretendard ml-2">일</span>
+        </div>
+  
+        <!-- Date Constraints -->
+        <div class="text-gray-3 text-xs text-center font-pretendard">
+          * 최소 7일, 최대 35일
+        </div>
+      </div>
+  
+      <!-- Complete Button -->
+      <div class="px-8 pb-[90px]">
+        <button
+          @click="completeInput"
+          :disabled="!isValidInput"
+          :class="[
+            'w-[328px] h-[56px] rounded-2xl font-normal transition font-pretendard',
+            isValidInput 
+              ? 'bg-brand text-white hover:bg-red-600' 
+              : 'bg-gray-5 text-gray-2 cursor-not-allowed'
+          ]"
+        >
+          입력 완료
+        </button>
+      </div>
+    </div>
+  </template>
+  
+  <script setup>
+  import { ref, computed, onMounted, onUnmounted } from 'vue';
+  import Header from '@/components/layout/Header.vue';
+  
+  // Props
+  const props = defineProps({
+    selectedChallenge: {
+      type: String,
+      required: true
+    }
+  });
+  
+  // Emits
+  const emit = defineEmits(['dateComplete']);
+  
+  // Reactive data
+  const selectedDays = ref(''); // 빈 문자열로 시작
+  const timeLeft = ref(30);
+  const timerInterval = ref(null);
+  
+  // Timer calculations
+  const circumference = 2 * Math.PI * 36.5; // 2πr
+  
+  const dashOffset = computed(() => {
+    const progress = timeLeft.value / 30;
+    return circumference * (1 - progress);
+  });
+  
+  // 입력값 유효성 검사
+  const isValidInput = computed(() => {
+    const num = Number(selectedDays.value);
+    return !isNaN(num) && num >= 7 && num <= 35;
+  });
+  
+  // Methods
+  const validateInput = () => {
+    // 숫자가 아닌 문자 제거
+    selectedDays.value = selectedDays.value.replace(/[^0-9]/g, '');
+  };
+  
+  const handleBlur = () => {
+    // 포커스를 잃었을 때는 아무것도 하지 않음 (강제 수정 안함)
+    if (selectedDays.value === '') {
+      // 빈 값일 때는 그대로 두기
+      return;
+    }
+  };
+  
+  const completeInput = () => {
+    if (isValidInput.value) {
+      emit('dateComplete', {
+        challenge: props.selectedChallenge,
+        days: Number(selectedDays.value)
+      });
+    }
+  };
+  
+  const startTimer = () => {
+    timerInterval.value = setInterval(() => {
+      timeLeft.value--;
+      
+      if (timeLeft.value <= 0) {
+        clearInterval(timerInterval.value);
+        // 시간 초과 시 랜덤 날짜 선택 (7-35일 사이)
+        const randomDays = Math.floor(Math.random() * (35 - 7 + 1)) + 7;
+        selectedDays.value = randomDays.toString();
+        
+        setTimeout(() => {
+          if (isValidInput.value) {
+            completeInput();
+          }
+        }, 500);
+      }
+    }, 1000);
+  };
+  
+  onMounted(() => {
+    startTimer();
+  });
+  
+  onUnmounted(() => {
+    if (timerInterval.value) {
+      clearInterval(timerInterval.value);
+    }
+  });
+  </script>
+  
+  <style scoped>
+  /* 숫자 입력 필드 스타일 */
+  input[type="number"] {
+    -webkit-appearance: none;
+    -moz-appearance: textfield;
+  }
+  
+  input[type="number"]::-webkit-outer-spin-button,
+  input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  
+  input[type="number"]:focus {
+    outline: none;
+    border-bottom: 2px solid #FF5555;
+  }
+  </style>

--- a/src/pages/challenge/ChallengeFlow.vue
+++ b/src/pages/challenge/ChallengeFlow.vue
@@ -1,0 +1,48 @@
+<template>
+    <div>
+      <!-- 1단계: Loading -->
+      <ChallengeLoading 
+        v-if="currentStep === 'loading'"
+        @loading-complete="handleLoadingComplete"
+      />
+      
+      <!-- 2단계: Selection -->
+      <ChallengeSelection 
+        v-else-if="currentStep === 'selection'"
+        @challenge-selected="handleChallengeSelected"
+      />
+      
+      <!-- 3단계: Days Input - 실제 컴포넌트 사용 -->
+      <ChallengeDaysInput 
+        v-if="currentStep === 'days-input'"
+        :selected-challenge="selectedChallenge"
+        @date-complete="handleDateComplete"
+      />
+    </div>
+  </template>
+  
+  <script setup>
+  import { ref } from 'vue';
+  import ChallengeLoading from './ChallengeLoading.vue';
+  import ChallengeSelection from './ChallengeSelection.vue';
+  import ChallengeDaysInput from './ChallengeDaysInput.vue'; // 주석 해제!
+  
+  const currentStep = ref('loading');
+  const selectedChallenge = ref(null);
+  
+  const handleLoadingComplete = () => {
+    console.log('✅ 로딩 완료 → 선택 페이지로');
+    currentStep.value = 'selection';
+  };
+  
+  const handleChallengeSelected = (challenge) => {
+    console.log('✅ 챌린지 선택됨:', challenge);
+    selectedChallenge.value = challenge;
+    currentStep.value = 'days-input';
+  };
+  
+  const handleDateComplete = (data) => {
+    console.log('✅ 날짜 입력 완료:', data);
+    // 여기서 다음 단계로 이동하거나 완료 처리
+  };
+  </script>

--- a/src/pages/challenge/ChallengeLoading.vue
+++ b/src/pages/challenge/ChallengeLoading.vue
@@ -1,0 +1,198 @@
+<template>
+    <div class="flex flex-col h-screen bg-default">
+      <!-- Header -->
+      <Header 
+        :show-logo="true" 
+        :show-points="true" 
+        :points="1250" 
+      />
+  
+      <!-- Title Section - 타이머와 동일한 위치에서 제거 -->
+      <div class="flex flex-col items-center pt-[60px] pb-4">
+        <!-- 빈 공간 유지 -->
+      </div>
+  
+      <!-- Loading Content - 중앙 배치 -->
+      <div class="flex-1 flex flex-col items-center justify-center px-8">
+        <!-- Loading Icon -->
+        <div class="w-16 h-16 mb-8">
+          <svg class="w-16 h-16 text-white animate-spin-slow" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11.03L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.22,8.95 2.27,9.22 2.46,9.37L4.57,11.03C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.22,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.68 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"/>
+          </svg>
+        </div>
+  
+        <!-- Loading Text -->
+        <h2 class="text-white text-xl font-bold text-center mb-4 font-pretendard">
+          AI가 적합한 챌린지를 찾고 있습니다
+        </h2>
+        
+        <div class="text-white/70 text-sm text-center font-pretendard">
+          <p>지난 소비내역을 기준으로</p>
+          <p>과소비를 판단합니다</p>
+        </div>
+      </div>
+  
+      <!-- Blurred Challenge Cards - 원본과 동일한 위치 -->
+      <div class="px-4 pb-4">
+        <div class="space-y-4 flex flex-col items-center blur-sm opacity-50">
+          <!-- 카페 금지 챌린지 -->
+          <div class="w-[328px] h-[98px] bg-default border-2 border-gray-1 rounded-2xl p-4 flex items-center gap-4">
+            <div class="w-12 h-12 bg-gray-1 rounded-full flex items-center justify-center">
+              <svg class="w-6 h-6 text-cafe" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M2,21V19H20V21H2M20,8V5L18,5V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+              </svg>
+            </div>
+            <div class="flex-1 text-left">
+              <h3 class="text-white text-base font-bold">카페 금지 챌린지</h3>
+              <p class="text-gray-3 text-sm">카페에서 결제하지 않기</p>
+            </div>
+          </div>
+  
+          <!-- 배달 음식 금지 챌린지 -->
+          <div class="w-[328px] h-[98px] bg-default border-2 border-gray-1 rounded-2xl p-4 flex items-center gap-4">
+            <div class="w-12 h-12 bg-gray-1 rounded-full flex items-center justify-center">
+              <svg class="w-6 h-6 text-delivery" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M19,7C19.74,7 20.38,7.37 20.73,7.93L23.73,12.93C23.9,13.21 24,13.53 24,13.86V18A1,1 0 0,1 23,19H21A3,3 0 0,1 18,22A3,3 0 0,1 15,19H9A3,3 0 0,1 6,22A3,3 0 0,1 3,19H1A1,1 0 0,1 0,18V6A1,1 0 0,1 1,5H17A1,1 0 0,1 18,6V7H19M18,9.5V13H22V13.86L19.5,9.5H18M6,17.5A1.5,1.5 0 0,0 4.5,19A1.5,1.5 0 0,0 6,20.5A1.5,1.5 0 0,0 7.5,19A1.5,1.5 0 0,0 6,17.5M18,17.5A1.5,1.5 0 0,0 16.5,19A1.5,1.5 0 0,0 18,20.5A1.5,1.5 0 0,0 19.5,19A1.5,1.5 0 0,0 18,17.5Z"/>
+              </svg>
+            </div>
+            <div class="flex-1 text-left">
+              <h3 class="text-white text-base font-bold">배달 음식 금지 챌린지</h3>
+              <p class="text-gray-3 text-sm">배달 음식 시키지 않기</p>
+            </div>
+          </div>
+  
+          <!-- 택시 금지 챌린지 -->
+          <div class="w-[328px] h-[98px] bg-default border-2 border-gray-1 rounded-2xl p-4 flex items-center gap-4">
+            <div class="w-12 h-12 bg-gray-1 rounded-full flex items-center justify-center">
+              <svg class="w-5 h-5 text-taxi" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M18.92,6.01C18.72,5.42 18.16,5 17.5,5H15V4A2,2 0 0,0 13,2H11A2,2 0 0,0 9,4V5H6.5C5.84,5 5.28,5.42 5.08,6.01L3,12V20A1,1 0 0,0 4,21H5A1,1 0 0,0 6,20V19H18V20A1,1 0 0,0 19,21H20A1,1 0 0,0 21,20V12L18.92,6.01M6.5,7H17.5L19,11H5L6.5,7M7.5,16A1.5,1.5 0 0,1 6,14.5A1.5,1.5 0 0,1 7.5,13A1.5,1.5 0 0,1 9,14.5A1.5,1.5 0 0,1 7.5,16M16.5,16A1.5,1.5 0 0,1 15,14.5A1.5,1.5 0 0,1 16.5,13A1.5,1.5 0 0,1 18,14.5A1.5,1.5 0 0,1 16.5,16Z"/>
+              </svg>
+            </div>
+            <div class="flex-1 text-left">
+              <h3 class="text-white text-base font-bold">택시 금지 챌린지</h3>
+              <p class="text-gray-3 text-sm">택시 타지 않기</p>
+            </div>
+          </div>
+        </div>
+      </div>
+  
+      <!-- Bottom Space - 원본과 동일한 여백 -->
+      <div class="px-8 pb-[90px]">
+        <!-- 빈 공간 유지 -->
+      </div>
+    </div>
+  </template>
+  
+  <script setup>
+  import { ref, computed, onMounted } from 'vue';
+  import Header from '@/components/layout/Header.vue';
+  
+  // Props
+  const props = defineProps({
+    selectedChallenge: {
+      type: String,
+      required: true
+    }
+  });
+  
+  // Emits
+  const emit = defineEmits(['loadingComplete']);
+  
+  // 챌린지 정보 매핑
+  const challengeInfo = {
+    cafe: {
+      title: '카페 금지 챌린지',
+      description: '카페에서 결제하지 않기',
+      icon: 'CafeIcon',
+      iconColor: 'text-cafe'
+    },
+    delivery: {
+      title: '배달 음식 금지 챌린지', 
+      description: '배달 음식 시키지 않기',
+      icon: 'DeliveryIcon',
+      iconColor: 'text-delivery'
+    },
+    taxi: {
+      title: '택시 금지 챌린지',
+      description: '택시 타지 않기', 
+      icon: 'TaxiIcon',
+      iconColor: 'text-taxi'
+    }
+  };
+  
+  // Computed
+  const selectedChallengeTitle = computed(() => {
+    return challengeInfo[props.selectedChallenge]?.title || '';
+  });
+  
+  const selectedChallengeDescription = computed(() => {
+    return challengeInfo[props.selectedChallenge]?.description || '';
+  });
+  
+  const challengeIcon = computed(() => {
+    return challengeInfo[props.selectedChallenge]?.icon || 'CafeIcon';
+  });
+  
+  const challengeIconColor = computed(() => {
+    return challengeInfo[props.selectedChallenge]?.iconColor || 'text-cafe';
+  });
+  
+  // 아이콘 컴포넌트들
+  const CafeIcon = {
+    template: `
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M2,21V19H20V21H2M20,8V5L18,5V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+      </svg>
+    `
+  };
+  
+  const DeliveryIcon = {
+    template: `
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M19,7C19.74,7 20.38,7.37 20.73,7.93L23.73,12.93C23.9,13.21 24,13.53 24,13.86V18A1,1 0 0,1 23,19H21A3,3 0 0,1 18,22A3,3 0 0,1 15,19H9A3,3 0 0,1 6,22A3,3 0 0,1 3,19H1A1,1 0 0,1 0,18V6A1,1 0 0,1 1,5H17A1,1 0 0,1 18,6V7H19M18,9.5V13H22V13.86L19.5,9.5H18M6,17.5A1.5,1.5 0 0,0 4.5,19A1.5,1.5 0 0,0 6,20.5A1.5,1.5 0 0,0 7.5,19A1.5,1.5 0 0,0 6,17.5M18,17.5A1.5,1.5 0 0,0 16.5,19A1.5,1.5 0 0,0 18,20.5A1.5,1.5 0 0,0 19.5,19A1.5,1.5 0 0,0 18,17.5Z"/>
+      </svg>
+    `
+  };
+  
+  const TaxiIcon = {
+    template: `
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <path d="M18.92,6.01C18.72,5.42 18.16,5 17.5,5H15V4A2,2 0 0,0 13,2H11A2,2 0 0,0 9,4V5H6.5C5.84,5 5.28,5.42 5.08,6.01L3,12V20A1,1 0 0,0 4,21H5A1,1 0 0,0 6,20V19H18V20A1,1 0 0,0 19,21H20A1,1 0 0,0 21,20V12L18.92,6.01M6.5,7H17.5L19,11H5L6.5,7M7.5,16A1.5,1.5 0 0,1 6,14.5A1.5,1.5 0 0,1 7.5,13A1.5,1.5 0 0,1 9,14.5A1.5,1.5 0 0,1 7.5,16M16.5,16A1.5,1.5 0 0,1 15,14.5A1.5,1.5 0 0,1 16.5,13A1.5,1.5 0 0,1 18,14.5A1.5,1.5 0 0,1 16.5,16Z"/>
+      </svg>
+    `
+  };
+  
+  onMounted(() => {
+    // 3초 후 로딩 완료하고 다음 화면으로 이동
+    setTimeout(() => {
+      console.log('챌린지 로딩 완료');
+      // 라우터를 사용한 페이지 이동 (실제 프로젝트에서는 router.push 사용)
+      // router.push('/challenge/start');
+      
+      // 또는 emit을 통해 부모 컴포넌트에 완료 신호 전달
+      emit('loadingComplete', props.selectedChallenge);
+    }, 3000);
+  });
+  </script>
+  
+  <style scoped>
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  
+  @keyframes spin-slow {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  
+  .animate-spin {
+    animation: spin 1s linear infinite;
+  }
+  
+  .animate-spin-slow {
+    animation: spin-slow 2s linear infinite;
+  }
+  </style>

--- a/src/pages/challenge/ChallengeSelection.vue
+++ b/src/pages/challenge/ChallengeSelection.vue
@@ -1,0 +1,201 @@
+<template>
+    <div class="flex flex-col h-screen bg-default">
+      <!-- Header -->
+      <Header 
+        :show-logo="true" 
+        :show-points="true" 
+        :points="1250" 
+      />
+  
+      <!-- Timer Circle - Top Section -->
+      <div class="flex flex-col items-center pt-[60px] pb-4">
+        <div class="relative mb-6">
+          <div class="w-20 h-20 relative">
+            <!-- Background Circle -->
+            <svg class="w-20 h-20 transform -rotate-90" viewBox="0 0 80 80">
+              <circle 
+                cx="40" 
+                cy="40" 
+                r="36.5" 
+                stroke="#414141" 
+                stroke-width="7" 
+                fill="none"
+              />
+              <!-- Progress Circle -->
+              <circle 
+                cx="40" 
+                cy="40" 
+                r="36.5" 
+                stroke="#FF5555" 
+                stroke-width="7" 
+                fill="none"
+                :stroke-dasharray="circumference"
+                :stroke-dashoffset="dashOffset"
+                stroke-linecap="round"
+                class="transition-all duration-1000 ease-linear"
+              />
+            </svg>
+            <!-- Timer Number -->
+            <div class="absolute inset-0 flex items-center justify-center">
+              <span class="text-white text-2xl font-normal font-pretendard">{{ timeLeft }}</span>
+            </div>
+          </div>
+        </div>
+  
+        <!-- Main Title -->
+        <h1 class="text-white text-xl font-bold text-center mb-2 font-pretendard">
+          원하는 챌린지를 선택해주세요
+        </h1>
+  
+        <!-- Subtitle -->
+        <div class="text-white/90 text-sm text-center font-pretendard">
+          <p>30초 후에 선택하지 않으면</p>
+          <p>AI 추천 챌린지가 선택됩니다</p>
+        </div>
+      </div>
+  
+      <!-- Middle Spacer -->
+      <div class="flex-1"></div>
+  
+      <!-- Challenge Cards - Bottom Section -->
+      <div class="px-4 pb-4">
+        <div class="space-y-4 flex flex-col items-center">
+          <!-- 카페 금지 챌린지 -->
+          <button 
+            @click="selectChallenge('cafe')"
+            :class="[
+              'w-[328px] h-[98px] bg-default border-2 rounded-2xl p-4 flex items-center gap-4 transition-colors',
+              selectedChallenge === 'cafe' ? 'border-brand' : 'border-gray-1'
+            ]"
+          >
+            <div class="w-12 h-12 bg-gray-1 rounded-full flex items-center justify-center">
+              <svg class="w-6 h-6 text-cafe" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M2,21V19H20V21H2M20,8V5L18,5V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+              </svg>
+            </div>
+            <div class="flex-1 text-left">
+              <h3 class="text-white text-base font-bold">카페 금지 챌린지</h3>
+              <p class="text-gray-3 text-sm">카페에서 결제하지 않기</p>
+            </div>
+          </button>
+  
+          <!-- 배달 음식 금지 챌린지 -->
+          <button 
+            @click="selectChallenge('delivery')"
+            :class="[
+              'w-[328px] h-[98px] bg-default border-2 rounded-2xl p-4 flex items-center gap-4 transition-colors',
+              selectedChallenge === 'delivery' ? 'border-brand' : 'border-gray-1'
+            ]"
+          >
+            <div class="w-12 h-12 bg-gray-1 rounded-full flex items-center justify-center">
+              <svg class="w-6 h-6 text-delivery" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M19,7C19.74,7 20.38,7.37 20.73,7.93L23.73,12.93C23.9,13.21 24,13.53 24,13.86V18A1,1 0 0,1 23,19H21A3,3 0 0,1 18,22A3,3 0 0,1 15,19H9A3,3 0 0,1 6,22A3,3 0 0,1 3,19H1A1,1 0 0,1 0,18V6A1,1 0 0,1 1,5H17A1,1 0 0,1 18,6V7H19M18,9.5V13H22V13.86L19.5,9.5H18M6,17.5A1.5,1.5 0 0,0 4.5,19A1.5,1.5 0 0,0 6,20.5A1.5,1.5 0 0,0 7.5,19A1.5,1.5 0 0,0 6,17.5M18,17.5A1.5,1.5 0 0,0 16.5,19A1.5,1.5 0 0,0 18,20.5A1.5,1.5 0 0,0 19.5,19A1.5,1.5 0 0,0 18,17.5Z"/>
+              </svg>
+            </div>
+            <div class="flex-1 text-left">
+              <h3 class="text-white text-base font-bold">배달 음식 금지 챌린지</h3>
+              <p class="text-gray-3 text-sm">배달 음식 시키지 않기</p>
+            </div>
+          </button>
+  
+          <!-- 택시 금지 챌린지 -->
+          <button 
+            @click="selectChallenge('taxi')"
+            :class="[
+              'w-[328px] h-[98px] bg-default border-2 rounded-2xl p-4 flex items-center gap-4 transition-colors',
+              selectedChallenge === 'taxi' ? 'border-brand' : 'border-gray-1'
+            ]"
+          >
+            <div class="w-12 h-12 bg-gray-1 rounded-full flex items-center justify-center">
+              <svg class="w-5 h-5 text-taxi" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M18.92,6.01C18.72,5.42 18.16,5 17.5,5H15V4A2,2 0 0,0 13,2H11A2,2 0 0,0 9,4V5H6.5C5.84,5 5.28,5.42 5.08,6.01L3,12V20A1,1 0 0,0 4,21H5A1,1 0 0,0 6,20V19H18V20A1,1 0 0,0 19,21H20A1,1 0 0,0 21,20V12L18.92,6.01M6.5,7H17.5L19,11H5L6.5,7M7.5,16A1.5,1.5 0 0,1 6,14.5A1.5,1.5 0 0,1 7.5,13A1.5,1.5 0 0,1 9,14.5A1.5,1.5 0 0,1 7.5,16M16.5,16A1.5,1.5 0 0,1 15,14.5A1.5,1.5 0 0,1 16.5,13A1.5,1.5 0 0,1 18,14.5A1.5,1.5 0 0,1 16.5,16Z"/>
+              </svg>
+            </div>
+            <div class="flex-1 text-left">
+              <h3 class="text-white text-base font-bold">택시 금지 챌린지</h3>
+              <p class="text-gray-3 text-sm">택시 타지 않기</p>
+            </div>
+          </button>
+        </div>
+      </div>
+  
+      <!-- Selection Button - Just above nav -->
+      <div class="px-8 pb-[90px]">
+        <button
+          :disabled="!selectedChallenge"
+          @click="startChallenge"
+          :class="[
+            'w-[328px] h-[56px] rounded-2xl font-normal transition',
+            selectedChallenge 
+              ? 'bg-brand text-white hover:bg-red-600' 
+              : 'bg-gray-5 text-gray-2'
+          ]"
+        >
+          {{ selectedChallenge ? '선택한 챌린지 시작하기' : '챌린지를 선택해주세요' }}
+        </button>
+      </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import Header from '@/components/layout/Header.vue';
+
+// Emit 이벤트 정의
+const emit = defineEmits(['challenge-selected']);
+
+const selectedChallenge = ref(null);
+const timeLeft = ref(30);
+const timerInterval = ref(null);
+
+const circumference = 2 * Math.PI * 36.5; // 2πr
+
+const dashOffset = computed(() => {
+  const progress = timeLeft.value / 30;
+  return circumference * (1 - progress);
+});
+
+const selectChallenge = (challenge) => {
+  selectedChallenge.value = challenge;
+};
+
+const startChallenge = () => {
+  if (selectedChallenge.value) {
+    console.log(`선택된 챌린지: ${selectedChallenge.value}`);
+    // 부모 컴포넌트(ChallengeFlow)에 이벤트 전달
+    emit('challenge-selected', selectedChallenge.value);
+  }
+};
+
+const startTimer = () => {
+  timerInterval.value = setInterval(() => {
+    timeLeft.value--;
+    
+    if (timeLeft.value <= 0) {
+      clearInterval(timerInterval.value);
+      // 시간 초과 시 랜덤 선택
+      const challenges = ['cafe', 'delivery', 'taxi'];
+      const randomChallenge = challenges[Math.floor(Math.random() * challenges.length)];
+      selectedChallenge.value = randomChallenge;
+      
+      setTimeout(() => {
+        startChallenge();
+      }, 500);
+    }
+  }, 1000);
+};
+
+onMounted(() => {
+  startTimer();
+});
+
+onUnmounted(() => {
+  if (timerInterval.value) {
+    clearInterval(timerInterval.value);
+  }
+});
+</script>
+
+<style scoped>
+/* 추가 스타일 */
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -55,6 +55,16 @@ const routes = [
     meta: { requiresAuth: true },
   },
   {
+    path: '/challenge/flow',
+    component: () => import('@/pages/challenge/ChallengeFlow.vue')
+  },
+{
+  path: '/challenge/days-input',
+  name: 'ChallengeDaysInput', 
+  component: () => import('../pages/challenge/ChallengeDaysInput.vue'),
+  meta: { requiresAuth: true },
+},
+  {
     path: '/no-chat',
     name: 'NoChat',
     component: () => import('@/pages/chat/NoChat.vue'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,7 +6,7 @@ import Account from '../pages/account/Account.vue';
 import ForgotPassword from '../pages/auth/ForgotPassword.vue';
 import Login from '../pages/auth/Login.vue';
 import Register from '../pages/auth/Register.vue';
-import Challenge from '../pages/challenge/Challenge.vue';
+import Challenge from '../pages/challenge/Challenge.vue'; // 챌린지 메인으로 직접 사용
 import Chat from '../pages/chat/Chat.vue';
 import Expenses from '../pages/expenses/Expenses.vue';
 import ExpenseEdit from '../pages/expenses/ExpenseEdit.vue';
@@ -51,7 +51,7 @@ const routes = [
   {
     path: '/challenge',
     name: 'Challenge',
-    component: Challenge,
+    component: Challenge, // Challenge.vue를 바로 메인 페이지로 사용
     meta: { requiresAuth: true },
   },
   {
@@ -138,6 +138,7 @@ const router = createRouter({
   routes,
 });
 
+// 인증 필요 라우트 처리
 router.beforeEach((to, from, next) => {
   const authStore = useAuthStore();
   const requiresAuth = to.matched.some((record) => record.meta.requiresAuth);


### PR DESCRIPTION
## 📌 관련 이슈
 closed #15

## ✨ 내용
챌린지 메인 페이지: 챌린지가 없을 때 빈 상태 화면 및 시작 버튼
챌린지 플로우 관리: 로딩 → 선택 → 날짜입력 단계별 진행
챌린지 로딩: AI 분석 중 표시되는 로딩 화면 (3초)
챌린지 선택: 3개 챌린지 중 1개 선택 (30초 타이머, 자동 랜덤 선택)
날짜 입력: 7-35일 범위에서 챌린지 기간 설정