### PR TITLE
[FIX] 소비 내역 불러오는 로직 수정

### DIFF
--- a/src/pages/expenses/Expenses.vue
+++ b/src/pages/expenses/Expenses.vue
@@ -396,7 +396,7 @@
 </template>
 
 <script setup>
-import { computed, ref, onMounted } from 'vue';
+import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useExpensesStore } from '../../stores/expenses.js';
 import Header from '../../components/layout/Header.vue';
@@ -404,11 +404,6 @@ import TransactionCard from '../../components/expenses/TransactionCard.vue';
 
 const router = useRouter();
 const expensesStore = useExpensesStore();
-
-// 컴포넌트가 처음 로드될 때 API를 호출하여 데이터를 가져옴
-onMounted(() => {
-  expensesStore.fetchExpensesFromAPI();
-});
 
 // 탭 상태 관리
 const activeTab = ref('account'); // 'account' 또는 'savings'

--- a/src/services/expensesService.js
+++ b/src/services/expensesService.js
@@ -5,9 +5,6 @@ export const expensesService = {
   async fetchExpenses(filters = {}) {
     try {
       const params = {
-        userId: 1, // 하드코딩된 userId 사용 (실제로는 인증된 사용자 ID 사용해야 함)
-        page: filters.page || 1,
-        limit: filters.limit || 50,
         categoryId: filters.categoryId,
         startDate: filters.dateRange?.start,
         endDate: filters.dateRange?.end,

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { authAPI } from '../utils/api';
+import { useExpensesStore } from './expenses'; // expenses 스토어 import
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
@@ -45,6 +46,14 @@ export const useAuthStore = defineStore('auth', {
         console.log('login: authAPI.login successful. Response:', response);
         // 로그인 성공 시 fetchMe를 호출하여 사용자 정보 및 인증 상태 업데이트 (강제 호출)
         await this.checkAuth(true);
+
+        // 로그인 성공 후 지출 내역 미리 로드
+        if (this.isAuthenticated) {
+          const expensesStore = useExpensesStore();
+          await expensesStore.fetchExpensesFromAPI();
+          console.log('login: Expenses pre-fetched.');
+        }
+
         console.log('login: checkAuth completed.');
         return true;
       } catch (error) {

--- a/src/stores/expenses.js
+++ b/src/stores/expenses.js
@@ -94,9 +94,8 @@ export const useExpensesStore = defineStore('expenses', () => {
   // 지출 내역 추가
   async function addTransaction(transactionData) {
     try {
-      const newTransaction =
-        await expensesService.createExpense(transactionData);
-      transactions.value.push(newTransaction);
+      await expensesService.createExpense(transactionData);
+      await fetchExpensesFromAPI(); // 데이터 변경 후 전체 내역 다시 로드
       return true;
     } catch (error) {
       console.error('거래내역 추가 실패:', error);
@@ -107,14 +106,8 @@ export const useExpensesStore = defineStore('expenses', () => {
   // 지출 내역 수정
   async function updateTransaction(id, updatedData) {
     try {
-      const updatedTransaction = await expensesService.updateExpense(
-        id,
-        updatedData
-      );
-      const index = transactions.value.findIndex((t) => t.id === id);
-      if (index !== -1) {
-        transactions.value[index] = updatedTransaction;
-      }
+      await expensesService.updateExpense(id, updatedData);
+      await fetchExpensesFromAPI(); // 데이터 변경 후 전체 내역 다시 로드
       return true;
     } catch (error) {
       console.error('거래내역 수정 실패:', error);
@@ -126,7 +119,7 @@ export const useExpensesStore = defineStore('expenses', () => {
   async function deleteTransaction(id) {
     try {
       await expensesService.deleteExpense(id);
-      transactions.value = transactions.value.filter((t) => t.id !== id);
+      await fetchExpensesFromAPI(); // 데이터 변경 후 전체 내역 다시 로드
       return true;
     } catch (error) {
       console.error('거래내역 삭제 실패:', error);
@@ -137,7 +130,6 @@ export const useExpensesStore = defineStore('expenses', () => {
   function setCurrentMonth(month) {
     if (month >= 1 && month <= 12) {
       currentMonth.value = month;
-      fetchExpensesFromAPI();
     }
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #80 

## ✨ 내용
로그인 시 데이터를 한 번만 불러오고, 월 이동 시에는 네트워크 요청 없이 이동하도록 수정.
하드코딩된 userId와 불필요한 page, limit 파라미터 제거
내역 추가, 수정, 삭제 시 최신 데이터로 동기화하도록 수정.

## 📸 스크린샷(선택)
<img width="334" height="66" alt="스크린샷 2025-08-06 11 23 49" src="https://github.com/user-attachments/assets/d3cd242c-5fd6-4359-b1d7-3042a41a5a88" />
