### PR TITLE
[FEAT] 홈페이지 독립적 월별 데이터 조회 및 Codef API 연동 새로고침 구현

### DIFF
--- a/src/pages/expenses/ExpenseEdit.vue
+++ b/src/pages/expenses/ExpenseEdit.vue
@@ -375,7 +375,7 @@ const validateInput = () => {
   const validation = expensesStore.validateTransaction(editableData);
 
   if (!validation.isValid) {
-    alert(validation.errors[0]); // 첫 번째 에러 메시지 표시
+    console.error('입력 유효성 검사 실패:', validation.errors[0]);
     return false;
   }
 
@@ -400,14 +400,14 @@ const saveTransaction = async () => {
   }
 
   if (success) {
-    alert(
+    console.log(
       isNewTransaction.value
         ? '거래내역이 추가되었습니다.'
         : '거래내역이 수정되었습니다.'
     );
     router.back();
   } else {
-    alert('저장에 실패했습니다. 다시 시도해주세요.');
+    console.error('저장에 실패했습니다.');
   }
 };
 
@@ -431,10 +431,10 @@ const deleteTransaction = async () => {
     const success = await expensesStore.deleteTransaction(transactionId.value);
     if (success) {
       console.log('삭제할 거래내역 ID:', transactionId.value);
-      alert('거래내역이 삭제되었습니다.');
+      console.log('거래내역이 삭제되었습니다.');
       router.back();
     } else {
-      alert('삭제에 실패했습니다. 다시 시도해주세요.');
+      console.error('삭제에 실패했습니다.');
     }
   }
 };

--- a/src/pages/expenses/Expenses.vue
+++ b/src/pages/expenses/Expenses.vue
@@ -457,12 +457,16 @@ const addTransaction = () => {
 const loading = computed(() => expensesStore.loading);
 
 const refreshExpenses = async () => {
-  console.log('지출 내역 새로고침 시작');
+  console.log('Codef 거래내역 새로고침 시작');
   try {
-    await expensesStore.fetchExpensesFromAPI();
-    console.log('지출 내역 새로고침 완료');
+    const success = await expensesStore.refreshFromCodef();
+    if (success) {
+      console.log('Codef 거래내역 새로고침 완료');
+    } else {
+      console.error('Codef 거래내역 새로고침 실패');
+    }
   } catch (error) {
-    console.error('지출 내역 새로고침 실패:', error);
+    console.error('Codef 거래내역 새로고침 오류:', error);
   }
 };
 </script>

--- a/src/services/expensesService.js
+++ b/src/services/expensesService.js
@@ -60,6 +60,24 @@ export const expensesService = {
       throw new Error(`카테고리 조회 실패: ${error.message}`);
     }
   },
+
+  // Codef 거래내역 새로고침
+  async refreshExpensesFromCodef() {
+    try {
+      return await expensesAPI.refresh();
+    } catch (error) {
+      throw new Error(`거래내역 새로고침 실패: ${error.message}`);
+    }
+  },
+
+  // 현재월 지출 집계 조회
+  async fetchCurrentMonthSummary() {
+    try {
+      return await expensesAPI.getCurrentMonthSummary();
+    } catch (error) {
+      throw new Error(`현재월 지출 집계 조회 실패: ${error.message}`);
+    }
+  },
 };
 
 export default expensesService;

--- a/src/stores/expenses.js
+++ b/src/stores/expenses.js
@@ -121,9 +121,8 @@ export const useExpensesStore = defineStore('expenses', () => {
   async function addTransaction(transactionData) {
     try {
       // 스토어에서 직접 데이터 변환
-      const apiData = this.transformTransactionToApiFormat(transactionData);
+      const apiData = transformTransactionToApiFormat(transactionData);
       await expensesService.createExpense(apiData);
-      await this.fetchExpensesFromAPI(); // 데이터 변경 후 전체 내역 다시 로드
       return true;
     } catch (error) {
       console.error('거래내역 추가 실패:', error);
@@ -135,9 +134,8 @@ export const useExpensesStore = defineStore('expenses', () => {
   async function updateTransaction(id, updatedData) {
     try {
       // 스토어에서 직접 데이터 변환
-      const apiData = this.transformTransactionToApiFormat(updatedData);
+      const apiData = transformTransactionToApiFormat(updatedData);
       await expensesService.updateExpense(id, apiData);
-      await this.fetchExpensesFromAPI(); // 데이터 변경 후 전체 내역 다시 로드
       return true;
     } catch (error) {
       console.error('거래내역 수정 실패:', error);
@@ -149,7 +147,6 @@ export const useExpensesStore = defineStore('expenses', () => {
   async function deleteTransaction(id) {
     try {
       await expensesService.deleteExpense(id);
-      await fetchExpensesFromAPI(); // 데이터 변경 후 전체 내역 다시 로드
       return true;
     } catch (error) {
       console.error('거래내역 삭제 실패:', error);

--- a/src/stores/expenses.js
+++ b/src/stores/expenses.js
@@ -99,6 +99,24 @@ export const useExpensesStore = defineStore('expenses', () => {
     }
   }
 
+  // Codef 거래내역 새로고침
+  async function refreshFromCodef() {
+    loading.value = true;
+    error.value = null;
+    try {
+      await expensesService.refreshExpensesFromCodef();
+      // 새로고침 후 데이터 다시 로드
+      await fetchExpensesFromAPI();
+      return true;
+    } catch (err) {
+      error.value = err.message;
+      console.error('Codef 새로고침 실패:', err);
+      return false;
+    } finally {
+      loading.value = false;
+    }
+  }
+
   // 지출 내역 추가
   async function addTransaction(transactionData) {
     try {
@@ -405,6 +423,7 @@ export const useExpensesStore = defineStore('expenses', () => {
     categoryMasterData, // Exposed for external use
     chartData,
     fetchExpensesFromAPI,
+    refreshFromCodef,
     addTransaction,
     updateTransaction,
     deleteTransaction,

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -82,6 +82,8 @@ export const expensesAPI = {
   update: (id, data) => api.put(`/expenses/${id}`, data),
   delete: (id) => api.delete(`/expenses/${id}`),
   getCategories: () => api.get('/expenses/categories'),
+  refresh: () => api.post('/expenses/refresh'),
+  getCurrentMonthSummary: () => api.get('/expenses/current-month-summary'),
 };
 
 export const savingAPI = {


### PR DESCRIPTION
## 📌 관련 이슈
closed #144 

## ✨ 내용
  Codef 새로고침 기능 연동
  - expensesService.js: 새로고침 및 월별 집계 API 메서드 추가
  - expenses.js 스토어: refreshFromCodef 액션 추가
  - Expenses.vue: Header의 버튼을 새로고침 기능으로 연결
  - nav바의 내역 버튼을 누르면 /expenses API를 호출하도록 수정 (SELECT 줄어들어서 성능문제x)

 Home 페이지 차트 데이터 개선
  - Home.vue: expensesStore 의존성 제거, 독립적 API 호출로 변경
  - 월별 지출 집계를 별도 API로 처리하여 성능 개선

  사용자 경험 개선
  - ExpenseEdit.vue: 모든 alert 창 제거 (console 로그로 대체)
  - 거래내역 생성/수정/삭제 시 즉시 페이지 이동

  Test
  - 새로고침 버튼 동작 확인
  - Home 페이지 차트 데이터 로딩 확인
  - 거래내역 CRUD 시 alert 창 제거 확인

<img width="361" height="327" alt="스크린샷 2025-08-14 025553" src="https://github.com/user-attachments/assets/7c0453a3-dcdd-4d0e-930b-3d425a69b12f" />
<img width="322" height="109" alt="스크린샷 2025-08-14 025543" src="https://github.com/user-attachments/assets/98cf4cdd-08e5-4ff0-a7f1-d6cf9a9f96d6" />
<img width="354" height="713" alt="스크린샷 2025-08-14 025529" src="https://github.com/user-attachments/assets/672326c6-9f51-4817-916a-7b46154f0c23" />


