### PR TITLE
[REFACTOR] 번들 크기 최적화 - 라우트 코드 분할 및 FontAwesome 최적화

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,50 +4,14 @@ import App from './App.vue';
 import router from './router';
 import './assets/styles/global.css';
 import { useAuthStore } from './stores/auth';
-import { library } from '@fortawesome/fontawesome-svg-core';
+// FontAwesome 전역 등록 제거 - 컴포넌트별 로컬 import로 변경
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { faCircleQuestion as farCircleQuestion } from '@fortawesome/free-regular-svg-icons';
-import {
-  faCircleQuestion as fasCircleQuestion,
-  faAngleRight,
-  faMotorcycle,
-  faMugSaucer,
-  faBagShopping,
-  faTaxi,
-  faStore,
-  faClapperboard,
-  faWineBottle,
-  faTrainSubway,
-  faSuitcaseMedical,
-  faHome,
-  faUtensils,
-  faEllipsis,
-  faCoins,
-} from '@fortawesome/free-solid-svg-icons';
-
-library.add(
-  farCircleQuestion,
-  fasCircleQuestion,
-  faAngleRight,
-  faMotorcycle,
-  faMugSaucer,
-  faBagShopping,
-  faTaxi,
-  faStore,
-  faClapperboard,
-  faWineBottle,
-  faTrainSubway,
-  faSuitcaseMedical,
-  faHome,
-  faUtensils,
-  faEllipsis,
-  faCoins
-);
 
 const app = createApp(App);
 const pinia = createPinia();
 
 app.use(pinia);
+// FontAwesome 컴포넌트 전역 등록
 app.component('FontAwesomeIcon', FontAwesomeIcon);
 
 // Define an async function for app initialization

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,24 +1,24 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import { useAuthStore } from '../stores/auth';
 
-// pages
-import Account from '../pages/account/Account.vue';
-import ForgotPassword from '../pages/auth/ForgotPassword.vue';
-import Login from '../pages/auth/Login.vue';
-import Register from '../pages/auth/Register.vue';
-import Challenge from '../pages/challenge/Challenge.vue'; // 챌린지 메인으로 직접 사용
-import Chat from '../pages/chat/Chat.vue';
-import Expenses from '../pages/expenses/Expenses.vue';
-import ExpenseEdit from '../pages/expenses/ExpenseEdit.vue';
-import NotFound from '../pages/error/NotFound.vue';
-import ServerError from '../pages/error/ServerError.vue';
-import Guide from '../pages/guide/Guide.vue';
-import Home from '../pages/home/Home.vue';
-import Profile from '../pages/profile/Profile.vue';
-import Edit from '../pages/profile/Edit.vue';
-import Terms from '../pages/profile/Terms.vue';
-import Policy from '../pages/profile/Policy.vue';
-import MyChallenge from '../pages/profile/MyChallenge.vue';
+// pages - 동적 import로 변경하여 번들 크기 최적화
+const Account = () => import('../pages/account/Account.vue');
+const ForgotPassword = () => import('../pages/auth/ForgotPassword.vue');
+const Login = () => import('../pages/auth/Login.vue');
+const Register = () => import('../pages/auth/Register.vue');
+const Challenge = () => import('../pages/challenge/Challenge.vue');
+const Chat = () => import('../pages/chat/Chat.vue');
+const Expenses = () => import('../pages/expenses/Expenses.vue');
+const ExpenseEdit = () => import('../pages/expenses/ExpenseEdit.vue');
+const NotFound = () => import('../pages/error/NotFound.vue');
+const ServerError = () => import('../pages/error/ServerError.vue');
+const Guide = () => import('../pages/guide/Guide.vue');
+const Home = () => import('../pages/home/Home.vue');
+const Profile = () => import('../pages/profile/Profile.vue');
+const Edit = () => import('../pages/profile/Edit.vue');
+const Terms = () => import('../pages/profile/Terms.vue');
+const Policy = () => import('../pages/profile/Policy.vue');
+const MyChallenge = () => import('../pages/profile/MyChallenge.vue');
 
 import OAuthRedirect from '../pages/auth/OAuthRedirect.vue';
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #165 

## ✨ 내용
초기 번들 크기 최적화를 통한 FCP/LCP 성능 개선

 ### 1. 라우트 코드 분할
  - **16개 모든 페이지**: 정적 import → 동적 import 변경
  - **코드 분할 달성**: 각 페이지가 별도 chunk로 분리
  - **초기 로딩 최적화**: 필요한 페이지만 로드

  ### 2. FontAwesome 최적화
  - **전역 아이콘 등록 제거**: main.js에서 15개 아이콘 library.add 삭제
  - **로컬 import 유지**: Home.vue, ChallengeProgress.vue에서 필요한 아이콘만 사용

  ### 📊 성능 개선 결과
  - **메인 번들 크기**: 245.83 KB → 236.74 KB (9.09 KB 감소)
  - **gzip 크기**: 89.59 KB → 85.99 KB (3.6 KB 감소)
  - **개선율**: 3.7% 번들 크기 절약

  ### ✅ 변경된 파일
  - `src/router/index.js`: 모든 페이지 동적 import 적용
  - `src/main.js`: FontAwesome 전역 등록 제거

## 📸 스크린샷(선택)
<img width="1494" height="867" alt="스크린샷 2025-08-16 173507" src="https://github.com/user-attachments/assets/6e6986e3-1ad2-459e-9b29-3768de1f2039" />
<img width="1556" height="863" alt="스크린샷 2025-08-16 173521" src="https://github.com/user-attachments/assets/2f88f1dd-36ee-4321-b999-d0c9d5d4143e" />
