### PR TITLE
[FIX] 배포 환경에서 채팅 연결 안됨

### DIFF
--- a/src/stores/chat.js
+++ b/src/stores/chat.js
@@ -6,8 +6,17 @@ import { chatApi } from '@/services/chatApi';
 
 // WebSocket URL 설정 통일
 const getWebSocketUrl = () => {
+  // 환경별 WebSocket URL 사용
+  const wsUrl = import.meta.env.VITE_WS_URL;
+  if (wsUrl) {
+    return `${wsUrl}/ws/chat`;
+  }
+  
+  // fallback: API URL에서 WebSocket URL 생성
   const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:8080';
-  return `${apiUrl}/ws/chat`;
+  const protocol = apiUrl.startsWith('https:') ? 'wss:' : 'ws:';
+  const cleanUrl = apiUrl.replace(/^https?:\/\//, '').replace('/api', '');
+  return `${protocol}//${cleanUrl}/ws/chat`;
 };
 
 export const useChatStore = defineStore('chat', () => {


### PR DESCRIPTION
## 📌 관련 이슈
closed #174 

## ✨ 내용
환경 별로 프로토콜 다르게 설정
- 개발환경: `ws://localhost:8080/ws/chat`
- 배포환경: `wss://dondothat.netlify.app/ws/chat`

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
