### PR TITLE
[BUG] 챌린지 status 변화시 채팅 접속 오류 수정

### DIFF
--- a/src/pages/chat/Chat.vue
+++ b/src/pages/chat/Chat.vue
@@ -267,9 +267,12 @@ const initializeChat = async () => {
 
     // 에러 발생 시 NoChat으로 이동 (상태 정보 포함)
     setTimeout(() => {
+      const errorStatus = error?.response?.data?.status || 'error';
+      // closed 상태는 기본 메시지로 처리
+      const queryStatus = errorStatus === 'closed' ? 'no_challenge' : errorStatus;
       router.push({ 
         path: '/no-chat', 
-        query: { status: error?.response?.data?.status || 'error' } 
+        query: { status: queryStatus } 
       });
     }, 2000);
   }

--- a/src/pages/chat/Chat.vue
+++ b/src/pages/chat/Chat.vue
@@ -212,6 +212,13 @@ const initializeChat = async () => {
     // 1. 사용자의 챌린지 상태 확인 (라우터 가드에서 확인했지만 최신 정보를 위해 다시 호출)
     const status = await chatStore.checkUserChallengeStatus();
 
+    // 추가 상태 검증: failed, completed, closed 상태에서는 채팅 접속 차단
+    if (!status.hasActiveChallenge || 
+        (status.status && status.status !== 'ongoing')) {
+      console.log('❌ 채팅 접속 불가능한 상태:', status);
+      throw new Error('채팅에 접속할 수 없는 상태입니다.');
+    }
+
     // 🚨 핵심: 사용자가 실제로 바뀌었는지 확인
     if (
       chatStore.currentUser?.userId &&
@@ -258,9 +265,12 @@ const initializeChat = async () => {
     console.error('❌ 채팅방 초기화 실패:', error);
     isCheckingStatus.value = false;
 
-    // 에러 발생 시 NoChat으로 이동
+    // 에러 발생 시 NoChat으로 이동 (상태 정보 포함)
     setTimeout(() => {
-      router.push('/no-chat');
+      router.push({ 
+        path: '/no-chat', 
+        query: { status: error?.response?.data?.status || 'error' } 
+      });
     }, 2000);
   }
 };

--- a/src/pages/chat/NoChat.vue
+++ b/src/pages/chat/NoChat.vue
@@ -21,10 +21,10 @@
       <!-- 메인 메시지 -->
       <div class="text-center mb-4 sm:mb-6">
         <h2 class="text-white text-lg sm:text-xl font-semibold font-pretendard mb-1 sm:mb-2">
-          참여 중인
+          {{ mainMessage.line1 }}
         </h2>
         <h2 class="text-white text-lg sm:text-xl font-semibold font-pretendard">
-          채팅방이 없어요
+          {{ mainMessage.line2 }}
         </h2>
       </div>
 
@@ -32,9 +32,8 @@
       <div class="text-center px-4">
         <p
           class="text-[#C9C9C9] text-xs sm:text-sm font-light font-pretendard leading-relaxed"
+          v-html="subMessage"
         >
-          챌린지에 도전 중이어야<br />
-          채팅에 참여 할 수 있어요
         </p>
       </div>
     </div>
@@ -42,7 +41,53 @@
 </template>
 
 <script setup>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
 import Header from '@/components/layout/Header.vue';
+
+const route = useRoute();
+
+// URL 쿼리 파라미터에서 상태 정보 가져오기
+const challengeStatus = computed(() => route.query.status || 'no_challenge');
+
+// 상태별 메시지 설정
+const mainMessage = computed(() => {
+  switch (challengeStatus.value) {
+    case 'failed':
+      return {
+        line1: '챌린지에',
+        line2: '실패했어요'
+      };
+    case 'completed':
+      return {
+        line1: '챌린지를',
+        line2: '완료했어요'
+      };
+    case 'closed':
+      return {
+        line1: '챌린지가',
+        line2: '종료되었어요'
+      };
+    default:
+      return {
+        line1: '참여 중인',
+        line2: '채팅방이 없어요'
+      };
+  }
+});
+
+const subMessage = computed(() => {
+  switch (challengeStatus.value) {
+    case 'failed':
+      return '챌린지에 실패하여<br />채팅방을 이용할 수 없어요';
+    case 'completed':
+      return '챌린지를 완료하여<br />채팅방이 종료되었어요';
+    case 'closed':
+      return '종료된 챌린지의<br />채팅방은 이용할 수 없어요';
+    default:
+      return '챌린지에 도전 중이어야<br />채팅에 참여 할 수 있어요';
+  }
+});
 </script>
 
 <style scoped>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -98,13 +98,23 @@ const routes = [
         
         const status = await chatStore.checkUserChallengeStatus();
         
+        // 첫 번째 체크: 활성 챌린지가 있는지 확인
         if (!status.hasActiveChallenge) {
-          // 챌린지가 없으면 no-chat으로 리다이렉트
-          next('/no-chat');
-        } else {
-          // 챌린지가 있으면 Chat 컴포넌트로 진행
-          next();
+          console.log('❌ 활성 챌린지가 없습니다:', status);
+          next({ path: '/no-chat', query: { status: status.status || 'no_challenge' } });
+          return;
         }
+        
+        // 두 번째 체크: 상태가 ongoing인지 직접 확인
+        if (status.status && status.status !== 'ongoing') {
+          console.log('❌ 챌린지 상태가 ongoing이 아닙니다:', status.status);
+          next({ path: '/no-chat', query: { status: status.status } });
+          return;
+        }
+        
+        // 모든 체크를 통과하면 채팅방 접속 허용
+        console.log('✅ 채팅방 접속 허용:', status);
+        next();
       } catch (error) {
         console.error('챌린지 상태 확인 실패:', error);
         // 에러 발생 시에도 no-chat으로 이동

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -108,7 +108,9 @@ const routes = [
         // 두 번째 체크: 상태가 ongoing인지 직접 확인
         if (status.status && status.status !== 'ongoing') {
           console.log('❌ 챌린지 상태가 ongoing이 아닙니다:', status.status);
-          next({ path: '/no-chat', query: { status: status.status } });
+          // closed 상태는 기본 메시지로 처리
+          const queryStatus = status.status === 'closed' ? 'no_challenge' : status.status;
+          next({ path: '/no-chat', query: { status: queryStatus } });
           return;
         }
         


### PR DESCRIPTION
## 📌 관련 이슈
closed #200 

## ✨ 내용
  1. 라우터 가드 강화 (src/router/index.js)

  - /chat 경로 접근 시 이중 상태 체크 추가
  - hasActiveChallenge 체크 + status !== 'ongoing' 직접 체크
  - failed/completed 상태 시 상태 정보와 함께 /no-chat으로 리다이렉트
  - closed 상태는 기본 메시지(no_challenge)로 처리

  2. Chat 컴포넌트 보안 강화 (src/pages/chat/Chat.vue)

  - initializeChat 메서드에서 추가 상태 검증 로직 추가
  - ongoing 상태가 아닐 경우 채팅 접속 차단
  - 에러 발생 시 상태 정보를 포함한 리다이렉트

  3. Chat Store 연결 로직 강화 (src/stores/chat.js)

  - connectToChat 메서드에서 연결 전 최종 상태 확인
  - preloadChallengeName 함수에서 ongoing 상태만 챌린지명 로드
  - 상태 불일치 시 명확한 에러 메시지 제공

  4. NoChat 페이지 메시지 개선 (src/pages/chat/NoChat.vue)

  - URL 쿼리 파라미터 기반 상태별 메시지 표시
  - failed: "챌린지에 실패했어요" + "챌린지에 실패하여 채팅방을 이용할 수 없어요"
  - completed: "챌린지를 완료했어요" + "챌린지를 완료하여 채팅방이 종료되었어요"
  - 기본: "참여 중인 채팅방이 없어요" + "챌린지에 도전 중이어야 채팅에 참여 할 수 있어요"